### PR TITLE
Record assignments to global variables and propagate into local scopes

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,10 @@ end
         @test softscope(TestMod, nl"let b::Int=2; a+=1; b=3; end") == nl"let b::Int=2; global a+=1; b=3; end"
         @test softscope(TestMod, nl"try; a=1; catch; b=2; finally; end") == nl"try; global a=1; catch; global b=2; finally; end"
         @test softscope(TestMod, nl"try; a=1; catch b; b=2; finally; end") == nl"try; global a=1; catch b; b=2; finally; end"
+        @test softscope(TestMod, nl"begin; aa=0; for i=1:10; aa+=i; end; end") == nl"begin; aa=0; for i=1:10; global aa+=i; end; end"
+        @test softscope(TestMod, nl"begin; (aa, bb)=(0, 1); for i=1:10; aa+=i; bb+=1; end; end") == nl"begin; (aa, bb)=(0, 1); for i=1:10; global aa+=i; global bb+=1; end; end"
+        @test softscope(TestMod, nl"begin; if true; aa=0; end; for i=1:10; aa+=i; end") == nl"begin; if true; aa=0; end; for i=1:10; global aa+=i; end"
+        @test softscope(TestMod, nl"begin; for i=1:10; a+=1; end; if a==0; aa=2; else aa=3; end; while aa > 0; aa -= 1; end; end") == nl"begin; for i=1:10; global a+=1; end; if a==0; aa=2; else aa=3; end; while aa > 0; global aa -= 1; end; end"
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,7 @@ end
         @test softscope(TestMod, nl"begin; local x; x = 0; for i = 1:10; x += i ; end ; end") == nl"begin; local x; x = 0; for i = 1:10; x += i ; end ; end"
         @test softscope(TestMod, nl"let x=1; x=0; for i = 1:10; x += i; end; end") == nl"let x=1; x=0; for i = 1:10; x += i; end; end"
         @test softscope(TestMod, nl"for i = 1:10; for j = 1:3; global x += 1; end; x = 3; end") == nl"for i = 1:10; for j = 1:3; global x += 1; end; x = 3; end"
+        @test softscope(TestMod, nl"let; global a = 0; for i = 1:10; a+=i; end; end") == nl"let; global a = 0; for i = 1:10; global a+=i; end; end"
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ end
         @test softscope(TestMod, nl"begin; local x; x = 0; for i = 1:10; x += i ; end ; end") == nl"begin; local x; x = 0; for i = 1:10; x += i ; end ; end"
         @test softscope(TestMod, nl"let x=1; x=0; for i = 1:10; x += i; end; end") == nl"let x=1; x=0; for i = 1:10; x += i; end; end"
         @test softscope(TestMod, nl"for i = 1:10; for j = 1:3; global x += 1; end; x = 3; end") == nl"for i = 1:10; for j = 1:3; global x += 1; end; x = 3; end"
-        @test softscope(TestMod, nl"let; global a = 0; for i = 1:10; a+=i; end; end") == nl"let; global a = 0; for i = 1:10; global a+=i; end; end"
+        @test softscope(TestMod, nl"let; global aa = 0; for i = 1:10; aa+=i; end; end") == nl"let; global aa = 0; for i = 1:10; global aa+=i; end; end"
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,7 @@ end
         @test softscope(TestMod, nl"for i = 1:10; let a = i ; println(a) ; end ; end") == nl"for i = 1:10; let a = i ; println(a) ; end ; end"
         @test softscope(TestMod, nl"begin; local x; x = 0; for i = 1:10; x += i ; end ; end") == nl"begin; local x; x = 0; for i = 1:10; x += i ; end ; end"
         @test softscope(TestMod, nl"let x=1; x=0; for i = 1:10; x += i; end; end") == nl"let x=1; x=0; for i = 1:10; x += i; end; end"
+        @test softscope(TestMod, nl"for i = 1:10; for j = 1:3; global x += 1; end; x = 3; end") == nl"for i = 1:10; for j = 1:3; global x += 1; end; x = 3; end"
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,9 @@ end
         @test softscope(TestMod, nl"begin; (aa, bb)=(0, 1); for i=1:10; aa+=i; bb+=1; end; end") == nl"begin; (aa, bb)=(0, 1); for i=1:10; global aa+=i; global bb+=1; end; end"
         @test softscope(TestMod, nl"begin; if true; aa=0; end; for i=1:10; aa+=i; end") == nl"begin; if true; aa=0; end; for i=1:10; global aa+=i; end"
         @test softscope(TestMod, nl"begin; for i=1:10; a+=1; end; if a==0; aa=2; else aa=3; end; while aa > 0; aa -= 1; end; end") == nl"begin; for i=1:10; global a+=1; end; if a==0; aa=2; else aa=3; end; while aa > 0; global aa -= 1; end; end"
+        @test softscope(TestMod, nl"for i = 1:10; let a = i ; println(a) ; end ; end") == nl"for i = 1:10; let a = i ; println(a) ; end ; end"
+        @test softscope(TestMod, nl"begin; local x; x = 0; for i = 1:10; x += i ; end ; end") == nl"begin; local x; x = 0; for i = 1:10; x += i ; end ; end"
+        @test softscope(TestMod, nl"let x=1; x=0; for i = 1:10; x += i; end; end") == nl"let x=1; x=0; for i = 1:10; x += i; end; end"
     end
 end
 


### PR DESCRIPTION
This PR allows recording of assignments done with blocks to allow statements like
```julia
if true
    aa = 0
end
for i = 1:10
    aa += i
end
```
to work even when `aa` has not been previously defined.

The key changes are to add any assigned variables to the `globals` variable whenever `insertglobal` is false (i.e., when in the global scope). Other assignment operators (+= and friends) are ignored as they will result in a `UndefVarError` if the variable isn't already a global variable.

One thing to note is that I've changed the behaviour of how `let` blocks were handled. Previously the `let` assignments (in contrast to the `let` body) were softscoped the inherited `insertglobal` value but (a) I don't understand why that is, and (b) it gives errors in cases like
```julia
softscope(Main, :(for i = 1:10; let a = i ; println(a) ; end ; end))
```
where `a` is a previously defined global.

The new way that let blocks are handled is to not softscope the assignments on the principle that it's pretty rare to try to assign to a global variable within the assignment statement of a `let` block, whereas the example above is not at all uncommon (particularly for programmatically defining functions).

It should be possible to do this properly but I'm not quite there yet on that one.