### PR TITLE
Add tuple assignments

### DIFF
--- a/src/SoftGlobalScope.jl
+++ b/src/SoftGlobalScope.jl
@@ -156,7 +156,7 @@ else
             if ex.args[1] in globals && !(ex.args[1] in locals) # Simple assignment to global
                 return Expr(:global, Expr(ex.head, ex.args[1], _softscope(ex.args[2], globals, locals, insertglobal)))
             end
-            softex = Expr(ex.head, _softscope.(ex.args, globals, locals, insertglobal)...)
+            softex = Expr(ex.head, _softscope.(ex.args, Ref(globals), Ref(locals), insertglobal)...)
             if isexpr(ex.args[1], :tuple) # Assignment to a tuple
                 vars = [var for var in localvars(ex.args[1].args) if (var in globals) && !(var in locals)]
                 return isempty(vars) ? softex : Expr(:block, Expr(:global, vars...), softex)

--- a/src/SoftGlobalScope.jl
+++ b/src/SoftGlobalScope.jl
@@ -69,7 +69,7 @@ else
     using Base.Meta: isexpr
 
     const assignments = Set((:(=), :(+=), :(-=), :(*=), :(/=), :(//=), :(\=), :(^=), :(÷=), :(%=), :(<<=), :(>>=), :(>>>=), :(|=), :(&=), :(⊻=), :($=)))
-    const calls = Set((:call, :comparison, :(&&), :(||), :ref))
+    const calls = Set((:call, :comparison, :(&&), :(||), :ref, :tuple))
 
     # extract the local variable names (e.g. `[:x]`) from assignments (e.g. `x=1`) etc.
     function localvars(ex::Expr)
@@ -152,7 +152,7 @@ else
             return Expr(ex.head, _softscope.(ex.args, Ref(globals), Ref(locals), insertglobal)...)
         elseif isexpr(ex, :kw)
             return Expr(ex.head, ex.args[1], _softscope(ex.args[2], globals, locals, insertglobal))
-        elseif insertglobal && ex.head in assignments 
+        elseif insertglobal && ex.head in assignments
             if isexpr(ex.args[1], :call)
                 return ex
             elseif ex.args[1] in globals && !(ex.args[1] in locals) # Simple assignment to global

--- a/src/SoftGlobalScope.jl
+++ b/src/SoftGlobalScope.jl
@@ -159,7 +159,7 @@ else
             elseif isexpr(ex.args[1], :tuple)
                 # Assignment to a tuple
                 vars = (var for var in localvars(ex.args[1].args) if (var in globals) && !(var in locals))
-                return Expr(:block, Expr(:global, Expr(:tuple, vars...)), Expr(ex.head, ex.args[1], _softscope(ex.args[2], globals, locals, insertglobal)))
+                return Expr(:block, Expr(:global, vars...), Expr(ex.head, ex.args[1], _softscope(ex.args[2], globals, locals, insertglobal)))
             end
         elseif !insertglobal && isexpr(ex, :(=)) # only assignments in the global scope need to be considered
             union!(globals, localvars(ex))

--- a/src/SoftGlobalScope.jl
+++ b/src/SoftGlobalScope.jl
@@ -69,7 +69,7 @@ else
     using Base.Meta: isexpr
 
     const assignments = Set((:(=), :(+=), :(-=), :(*=), :(/=), :(//=), :(\=), :(^=), :(÷=), :(%=), :(<<=), :(>>=), :(>>>=), :(|=), :(&=), :(⊻=), :($=)))
-    const calls = Set((:call, :comparison, :(&&), :(||)))
+    const calls = Set((:call, :comparison, :(&&), :(||), :ref))
 
     # extract the local variable names (e.g. `[:x]`) from assignments (e.g. `x=1`) etc.
     function localvars(ex::Expr)
@@ -149,11 +149,9 @@ else
             union!(locals, localvars(ex.args)) # affects globals in surrounding scope!
             return ex
         elseif ex.head in calls
-            return Expr(ex.head, (_softscope.(ex.args, Ref(globals), Ref(locals), insertglobal))...)
+            return Expr(ex.head, _softscope.(ex.args, Ref(globals), Ref(locals), insertglobal)...)
         elseif isexpr(ex, :kw)
-            return Expr(ex.head, ex.args[1], _softscope(ex.args[2], globals, locals, insertglobal))
-        elseif isexpr(ex, :ref)
-            return Expr(ex.head, ex.args[1], _softscope.(ex.args[2:end], Ref(globals), Ref(locals), insertglobal))
+            return Expr(ex.head, ex.args[1], _softscope(ex.args[2], globals, locals, insertglobal)...)
         elseif insertglobal && ex.head in assignments 
             if isexpr(ex.args[1], :call)
                 return ex

--- a/src/SoftGlobalScope.jl
+++ b/src/SoftGlobalScope.jl
@@ -152,8 +152,12 @@ else
             return Expr(ex.head, (_softscope.(ex.args, Ref(globals), Ref(locals), insertglobal))...)
         elseif isexpr(ex, :kw)
             return Expr(ex.head, ex.args[1], _softscope(ex.args[2], globals, locals, insertglobal))
+        elseif isexpr(ex, :ref)
+            return Expr(ex.head, ex.args[1], _softscope.(ex.args[2:end], Ref(globals), Ref(locals), insertglobal))
         elseif insertglobal && ex.head in assignments 
-            if ex.args[1] in globals && !(ex.args[1] in locals) # Simple assignment to global
+            if isexpr(ex.args[1], :call)
+                return ex
+            elseif ex.args[1] in globals && !(ex.args[1] in locals) # Simple assignment to global
                 return Expr(:global, Expr(ex.head, ex.args[1], _softscope(ex.args[2], globals, locals, insertglobal)))
             end
             softex = Expr(ex.head, _softscope.(ex.args, Ref(globals), Ref(locals), insertglobal)...)

--- a/src/SoftGlobalScope.jl
+++ b/src/SoftGlobalScope.jl
@@ -151,7 +151,7 @@ else
         elseif ex.head in calls
             return Expr(ex.head, _softscope.(ex.args, Ref(globals), Ref(locals), insertglobal)...)
         elseif isexpr(ex, :kw)
-            return Expr(ex.head, ex.args[1], _softscope(ex.args[2], globals, locals, insertglobal)...)
+            return Expr(ex.head, ex.args[1], _softscope(ex.args[2], globals, locals, insertglobal))
         elseif insertglobal && ex.head in assignments 
             if isexpr(ex.args[1], :call)
                 return ex

--- a/src/SoftGlobalScope.jl
+++ b/src/SoftGlobalScope.jl
@@ -158,8 +158,14 @@ else
                 return Expr(:global, Expr(ex.head, ex.args[1], _softscope(ex.args[2], globals, locals, insertglobal)))
             elseif isexpr(ex.args[1], :tuple)
                 # Assignment to a tuple
-                vars = (var for var in localvars(ex.args[1].args) if (var in globals) && !(var in locals))
-                return Expr(:block, Expr(:global, vars...), Expr(ex.head, ex.args[1], _softscope(ex.args[2], globals, locals, insertglobal)))
+                vars = [var for var in localvars(ex.args[1].args) if (var in globals) && !(var in locals)]
+                if length(vars) > 0
+                    return Expr(:block, Expr(:global, vars...), Expr(ex.head, ex.args[1], _softscope(ex.args[2], globals, locals, insertglobal)))
+                else
+                    return Expr(ex.head, ex.args[1], _softscope(ex.args[2], globals, locals, insertglobal))
+                end
+            else
+                return ex
             end
         elseif !insertglobal && isexpr(ex, :(=)) # only assignments in the global scope need to be considered
             union!(globals, localvars(ex))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,7 @@ end
         @test softscope(TestMod, nl"for i = 1:10; a,b,x = (i+a, a+b, i+1); end") == nl"for i = 1:10; begin; global a, b; a,b,x = (i+a, a+b, i+1); end; end"
         @test softscope(TestMod, nl"j=0; for i = 1:10; (a[j+=1],x) = (i, i+1); end") == nl"j=0; for i = 1:10; (a[global j+=1],x) = (i, i+1); end"
         @test softscope(TestMod, nl"myfunc(a) = (b = 0; for i = 1:10; b += i; a += b; end; a)") == nl"myfunc(a) = (b = 0; for i = 1:10; b += i; a += b; end; a)"
+        @test softscope(TestMod, nl"let; x = (a=1, aa=2); end") == nl"let; x = (a=1, aa=2); end"
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,6 +69,7 @@ end
         @test softscope(TestMod, nl"for i = 1:10; x,y = (i+1, i+2); end") == nl"for i = 1:10; x,y = (i+1, i+2); end"
         @test softscope(TestMod, nl"for i = 1:10; a,x = (i+a, i+1); end") == nl"for i = 1:10; begin; global a; a,x = (i+a, i+1); end; end"
         @test softscope(TestMod, nl"for i = 1:10; a,b,x = (i+a, a+b, i+1); end") == nl"for i = 1:10; begin; global a, b; a,b,x = (i+a, a+b, i+1); end; end"
+        @test softscope(TestMod, nl"j=0; for i = 1:10; (a[j+=1],x) = (i, i+1); end") == nl"j=0; for i = 1:10; (a[global j+=1],x) = (i, i+1); end"
         @test softscope(TestMod, nl"myfunc(a) = (b = 0; for i = 1:10; b += i; a += b; end; a)") == nl"myfunc(a) = (b = 0; for i = 1:10; b += i; a += b; end; a)"
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,9 @@ end
         @test softscope(TestMod, nl"for i=r; true && (a += 1); end") == nl"for i=r; true && (global a += 1); end"
         @test softscope(TestMod, nl"for i=r; true || (a += 1); end") == nl"for i=r; true || (global a += 1); end"
         @test softscope(TestMod, nl"for i=r; 0 < (a += 1) < 10; end") == nl"for i=r; 0 < (global a += 1) < 10; end"
+        @test softscope(TestMod, nl"for i = 1:10; x,y = (i+1, i+2); end") == nl"for i = 1:10; x,y = (i+1, i+2); end"
+        @test softscope(TestMod, nl"for i = 1:10; a,x = (i+a, i+1); end") == nl"for i = 1:10; begin; global a; a,x = (i+a, i+1); end; end"
+        @test softscope(TestMod, nl"for i = 1:10; a,b,x = (i+a, a+b, i+1); end") == nl"for i = 1:10; begin; global a, b; a,b,x = (i+a, a+b, i+1); end; end"
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,6 +69,7 @@ end
         @test softscope(TestMod, nl"for i = 1:10; x,y = (i+1, i+2); end") == nl"for i = 1:10; x,y = (i+1, i+2); end"
         @test softscope(TestMod, nl"for i = 1:10; a,x = (i+a, i+1); end") == nl"for i = 1:10; begin; global a; a,x = (i+a, i+1); end; end"
         @test softscope(TestMod, nl"for i = 1:10; a,b,x = (i+a, a+b, i+1); end") == nl"for i = 1:10; begin; global a, b; a,b,x = (i+a, a+b, i+1); end; end"
+        @test softscope(TestMod, nl"myfunc(a) = (b = 0; for i = 1:10; b += i; a += b; end; a)") == nl"myfunc(a) = (b = 0; for i = 1:10; b += i; a += b; end; a)"
     end
 end
 


### PR DESCRIPTION
A quick WIP for #17. Doesn't quite work... Just thought I'd share this now as not sure when I'll next have a few minutes.

Key point is that we cannot add the global annotation inside a tuple assignment and so we have to create an extra block with an explicit global declaration.